### PR TITLE
Support ESP-IDF v4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 While there is [no support for USB devices on WSL2](https://github.com/microsoft/WSL/issues/4322) for now, this tool comes to help you to flash and monitor [ESP-IDF](https://github.com/espressif/esp-idf) applications on the [WSL2](https://docs.microsoft.com/en-us/windows/wsl/compare-versions).
 
-> **Info:**<br>Tested on [Ubuntu 20.04 LTS](https://www.microsoft.com/en-us/p/ubuntu-2004-lts/9n6svws3rx71) distribution.
+> **Info:**<br>Tested on [Ubuntu 20.04 LTS](https://www.microsoft.com/en-us/p/ubuntu-2004-lts/9n6svws3rx71) and [Debian](https://www.microsoft.com/en-us/p/debian/9msvkqc78pk6) distributions.
 
 > **Note:**<br>As a prerequisite for using this tool, [Python :snake:](https://www.python.org) needs to be installed on the Windows.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ idfx COMMAND PORT [monitor]
 Execute next command inside of your WSL to install `idfx`
 
 ```sh
-curl -L https://raw.githubusercontent.com/abobija/idfx/main/idfx -o $HOME/.local/bin/idfx && chmod u+x $HOME/.local/bin/idfx
+wget https://raw.githubusercontent.com/abobija/idfx/main/idfx -O $HOME/.local/bin/idfx && chmod u+x $HOME/.local/bin/idfx
 ```
 
 # Examples

--- a/idfx
+++ b/idfx
@@ -94,7 +94,7 @@ if [ "$1" = 'flash' ]; then
 		-p $2
 		-b 460800 --before default_reset --after hard_reset
 		--chip $idf_target
-		write_flash "; cat build/flash_args) | tr '\n' ' ')
+		write_flash "; cat build/flash_project_args) | tr '\n' ' ')
 	
 	powershell.exe -Command "cd build ; $flash_cmd"
 fi


### PR DESCRIPTION
Closes #1

This PR added support for ESP-IDF v4.1 by using **flash_project_args** instead of **flash_args** file inside of `build` folder.
The latest version, at this moment, v4.3 generates **flash_project_args** file as well, so this PR will not break support for the latest version.