### PR TITLE
Support esptool.exe on Windows

### DIFF
--- a/idfx
+++ b/idfx
@@ -89,7 +89,7 @@ idfx_build() {
 idfx_flash() {
 	if ! idfx_environment_check; then return $IDFX_FAIL; fi
 
-	local cmd=$((echo "esptool.py -p $1 -b 460800 --before default_reset --after hard_reset --chip $IDFX_TARGET write_flash "; cat build/flash_project_args) | tr '\n' ' ')
+	local cmd=$((echo "python.exe -m esptool -p $1 -b 460800 --before default_reset --after hard_reset --chip $IDFX_TARGET write_flash "; cat build/flash_project_args) | tr '\n' ' ')
 	powershell.exe -Command "cd build ; $cmd"
 
 	return $?
@@ -98,7 +98,7 @@ idfx_flash() {
 idfx_erase_flash() {
 	if ! idfx_environment_check; then return $IDFX_FAIL; fi
 
-	local cmd="esptool.py -p $1 -b 460800 --chip $IDFX_TARGET erase_flash"
+	local cmd="python.exe -m esptool -p $1 -b 460800 --chip $IDFX_TARGET erase_flash"
 	powershell.exe -Command "$cmd"
 
 	return $?
@@ -161,8 +161,12 @@ elif [ "$1" == 'all' ]; then
 	idfx_build && idfx_flash $2 && idfx_monitor $2
 elif [ "$1" == 'flash' ]; then
 	idfx_flash $2
+
+	if [[ $# -gt 2 && "$3" == 'monitor' ]]; then
+		idfx_monitor $2
+	fi
 elif [ "$1" == 'erase_flash' ]; then
 	idfx_erase_flash $2
-elif [[ "$1" == 'monitor' ]] || [[ $# -gt 2 && "$3" == 'monitor' ]]; then
+elif [[ "$1" == 'monitor' ]]; then
 	idfx_monitor $2
 fi


### PR DESCRIPTION
resolves #9

Support esptool package when it is installed as .exe on Windows.
Fixed issue with calling `idfx flash COMX monitor` when monitoring was not invoked.

Thanks to @adokitkat for feedback.