### PR TITLE
Replace deprecated pkgutil.find_loader with importlib.util.find_spec

### DIFF
--- a/idfx
+++ b/idfx
@@ -115,7 +115,7 @@ idfx_check_esptool() {
     return $IDFX_FAIL
   fi
 
-  if [[ $(python.exe -c 'import pkgutil; print(1 if pkgutil.find_loader("esptool") else 0)') != '1'* ]]; then
+  if [[ $(python.exe -c 'import importlib.util; print(1 if importlib.util.find_spec("esptool") else 0)') != '1'* ]]; then
     idfx_err 'Python package "esptool" needs to be installed on the Windows.'
     read -p 'Would you like to install it now (y/n): ' answer
 
@@ -143,7 +143,7 @@ idfx_check_esp_idf_monitor() {
     return $IDFX_FAIL
   fi
 
-  if [[ $(python.exe -c 'import pkgutil; print(1 if pkgutil.find_loader("esp_idf_monitor") else 0)') != '1'* ]]; then
+  if [[ $(python.exe -c 'import importlib.util; print(1 if importlib.util.find_spec("esp_idf_monitor") else 0)') != '1'* ]]; then
     idfx_err 'Python package "esp_idf_monitor" needs to be installed on the Windows.'
     read -p 'Would you like to install it now (y/n): ' answer
 


### PR DESCRIPTION
pkgutil.find_loader was deprecated in Python 3.12. At the moment Python just emits a warning, but in Python 3.14, pkgutil.find_loader will be removed. This PR replaces pkgutil.find_loader with the recommended substitute importlib.util.find_spec.

This will break idfx on installations that have Python <= 3.4. I don't think this will be a problem, given that the latest version of esptool requires Python >= 3.7. But I can imagine there might be migrated installations out there using old versions of Python and esptool, so here's something for the search engines:

If you're getting ````ModuleNotFoundError: No module named 'importlib.util'```` or ````AttributeError: module 'importlib.util' has no attribute 'find_spec'```` when running idfx, your Windows-side (i.e. not within WSL2) Python installation is too old. Upgrade it to Python >= 3.4.